### PR TITLE
Change name of type from VRO to vROps

### DIFF
--- a/ui/src/app/pages/sddcsoftware/component/vmware/vmware-config-list/vmware-config-list.component.ts
+++ b/ui/src/app/pages/sddcsoftware/component/vmware/vmware-config-list/vmware-config-list.component.ts
@@ -133,7 +133,12 @@ export class VmwareConfigListComponent implements OnInit {
     this.service.getVmwareConfigData(currentPage,pageSize).subscribe(
       (data)=>{if(data.status == 200){
         this.vmwareConfigs = data.json().content;
-        this.vmwareConfigs.forEach(element=>{    
+        this.vmwareConfigs.forEach(element=>{  
+          if(element.type == "VRO"){
+            element.type = "vROps";
+          }else if(element.type == "VCENTER"){
+            element.type ="vCenter";
+          }  
           this.checkStatus(element);
         })
         this.currentPage = data.json().number+1;


### PR DESCRIPTION
change name of type from VCENTER to vCenter

Signed-off-by: Pengpeng Wang <pengpengw@vmware.com>