### PR TITLE
Fix infoblox login validation error.

### DIFF
--- a/flowgate-api/src/main/java/com/vmware/flowgate/auth/ServerAuth.java
+++ b/flowgate-api/src/main/java/com/vmware/flowgate/auth/ServerAuth.java
@@ -62,7 +62,6 @@ public class ServerAuth {
       } else {
          restTemplate = new RestTemplate();
       }
-      restTemplate.getForEntity(softwareConfig.getServerURL(), String.class);
       return restTemplate;
    }
 }


### PR DESCRIPTION
The default getConnection method will try to ping the baseURL, in Infoblox case, the api gateway will return 404 error if flowgate try to access the base url. So we remove the defaul ping action in the method.

Signed-off-by: Yixing Jia<yixingj@vmware.com>