### PR TITLE
Fix java command not found in the baseimage of flowgate-v1.2.0

### DIFF
--- a/make/baseimage/Dockerfile
+++ b/make/baseimage/Dockerfile
@@ -1,7 +1,12 @@
 FROM photon:2.0
 
 RUN tdnf distro-sync -y \
+	&& tdnf install libstdc++ -y \
 	&& tdnf install openjdk11.x86_64 -y \
 	&& mkdir /log \
 	&& mkdir /jar \
 	&& mkdir /conf
+
+ENV JAVA_HOME=/usr/lib/jvm/OpenJDK-11.0
+ENV PATH=$PATH:$JAVA_HOME/bin
+


### PR DESCRIPTION
issue #897 

java command can't be found in the baseimage

Signed-off-by: Huaqiao Zhang <huaqiaoz@vmware.com>

